### PR TITLE
Update auto_tune.py

### DIFF
--- a/auto_tune.py
+++ b/auto_tune.py
@@ -440,7 +440,7 @@ class auto_tune(plugins.Plugin):
     # called when an epoch is over (where an epoch is a single loop of the main algorithm)
     def on_epoch(self, agent, epoch, epoch_data):
         # pick set of channels for next time
-        if agent._config['ai']['enabled']:
+        if agent._config.get('ai', {}).get('enabled', False):
             return
 
         try:


### PR DESCRIPTION
With the new versions of jayofelony's fork of pwnagotchi, the ai config parameter is depreciated. This makes the auto_tune.py plugin break since it is expected in the code.

```
[2024-12-22 16:05:32,002] [ERROR] [Thread-11] : KeyError('ai')
Traceback (most recent call last):
  File "/home/pi/.pwn/lib/python3.11/site-packages/pwnagotchi/plugins/__init__.py", line 96, in process_events
    self.process_event(event_name, *args, **kwargs)
  File "/home/pi/.pwn/lib/python3.11/site-packages/pwnagotchi/plugins/__init__.py", line 85, in process_event
    callback(*args, **kwargs)
  File "/usr/local/share/pwnagotchi/custom-plugins/auto_tune.py", line 443, in on_epoch
    if agent._config['ai']['enabled']:
       ~~~~~~~~~~~~~^^^^^^
KeyError: 'ai'
```

This fix mitigates this issue